### PR TITLE
Transient mark mode

### DIFF
--- a/hungry-delete.el
+++ b/hungry-delete.el
@@ -105,7 +105,6 @@ region."
 	;; Otherwise, call hungry-delete-forward-iter.
 	(t (hungry-delete-forward-iter))))
 
-;;;###autoload
 (defun hungry-delete-forward-iter ()  
   (let ((here (point)))
     (hungry-delete-skip-ws-forward)
@@ -133,7 +132,6 @@ region."
 	;; Otherwise, call hungry-delete-backward-iter.
 	(t (hungry-delete-backward-iter))))
 
-;;;###autoload
 (defun hungry-delete-backward-iter ()
   (let ((here (point)))
     (hungry-delete-skip-ws-backward)


### PR DESCRIPTION
delete-forward-char and delete-backward-char obey Transient Mark mode: if a region is selected, either command, if called, will delete (or kill) that region. 

The hungry-delete equivalents do not currently obey that behavior. This patch adapts code from the original functions to do so. I think this works, although the implementation may leave something to be desired.

Also, delete-backward-char has some code that untabifies text if overwrite mode is on, but that requires a prefix argument to implement.
