### PR TITLE
Use prefixes, import functionality.

### DIFF
--- a/hungry-delete.el
+++ b/hungry-delete.el
@@ -119,10 +119,11 @@ KILLFLAG is set if N was explicitly specified."
 	 (if (eq delete-active-region 'kill)
 	     (kill-region (region-beginning) (region-end))
 	   (delete-region (region-beginning) (region-end))))
-	;; If a prefix argument is given, delete n characters.
-	((/= n 1) (delete-char n killflag))
-	;; Otherwise, call hungry-delete-forward-iter.
-	(t (hungry-delete-forward-iter))))
+	;; If a prefix argument is not given, call hungry-delete-forward-iter.
+	((eq current-prefix-arg ())
+	 (hungry-delete-forward-iter))
+	;; Otherwise, a prefix has been given, so delete n characters.
+	(t (delete-char n killflag))))
 
 (defun hungry-delete-forward-iter ()
   (let ((here (point)))
@@ -170,10 +171,11 @@ arg, and KILLFLAG is set if N is explicitly specified."
            (delete-char (- n) killflag)
 	   (save-excursion
 	     (insert-char ?\s (- ocol (current-column)) nil))))
-	;; If a prefix argument is given, delete n characters.
-	((/= n 1) (delete-char (- n) killflag))
-	;; Otherwise, call hungry-delete-backward-iter.
-	(t (hungry-delete-backward-iter))))
+	;; If a prefix argument is not given, call hungry-delete-backward-iter.
+	((eq current-prefix-arg ())
+	 (hungry-delete-backward-iter))
+	;; Otherwise, a prefix has been given, so delete n characters backwards.
+	(t (delete-char (- n) killflag))))
 
 (defun hungry-delete-backward-iter ()
   (let ((here (point)))


### PR DESCRIPTION
hungry-delete-forward and -backward are extensions of delete-forward-char and delete-backward-char. Recent patches took into account that those original versions work in Delete Selection mode / Transient Mark mode. This patch takes into account that the originals use prefix arguments.

Not only does this allow deleting a specific number of characters (whitespace or otherwise), but it also means that Hungry can basically mimic all of the stock features of the original versions, including untabifying with Overwrite mode.
