### PR TITLE
Return to original order for conditional.

### DIFF
--- a/hungry-delete.el
+++ b/hungry-delete.el
@@ -119,11 +119,11 @@ KILLFLAG is set if N was explicitly specified."
 	 (if (eq delete-active-region 'kill)
 	     (kill-region (region-beginning) (region-end))
 	   (delete-region (region-beginning) (region-end))))
-	;; If a prefix argument is not given, call hungry-delete-forward-iter.
-	((eq current-prefix-arg ())
-	 (hungry-delete-forward-iter))
-	;; Otherwise, a prefix has been given, so delete n characters.
-	(t (delete-char n killflag))))
+	;; If a prefix argument has been given, delete n characters.
+	((identity current-prefix-arg)
+	 (delete-char n killflag))
+	;; Otherwise, call hungry-delete-forward-iter.
+	(t (hungry-delete-forward-iter))))
 
 (defun hungry-delete-forward-iter ()
   (let ((here (point)))
@@ -171,11 +171,11 @@ arg, and KILLFLAG is set if N is explicitly specified."
            (delete-char (- n) killflag)
 	   (save-excursion
 	     (insert-char ?\s (- ocol (current-column)) nil))))
-	;; If a prefix argument is not given, call hungry-delete-backward-iter.
-	((eq current-prefix-arg ())
-	 (hungry-delete-backward-iter))
-	;; Otherwise, a prefix has been given, so delete n characters backwards.
-	(t (delete-char (- n) killflag))))
+	;; If a prefix argument has been given, delete n characters backwards.
+	((identity current-prefix-arg)
+	 (delete-char (- n) killflag))
+	;; Otherwise, call hungry-delete-backward-iter.
+	(t (hungry-delete-backward-iter))))
 
 (defun hungry-delete-backward-iter ()
   (let ((here (point)))


### PR DESCRIPTION
In implementing prefix arguments, I switched the order of the
conditional questions, but I think the original order is more
logical. This version maintains the same functionality in the original,
more intuitive order.
