### PR TITLE
fix, when `(point)` at EOL of wdired buffer

### DIFF
--- a/hungry-delete.el
+++ b/hungry-delete.el
@@ -89,7 +89,7 @@ line continuations."
              (= (point) (point-min))
              (< (skip-chars-backward hungry-delete-chars-to-skip) 0)
              (forward-char)))))
-  (while (get-text-property (point) 'read-only)
+  (while (and (get-text-property (point) 'read-only) (not (eolp)))
     (forward-char)))
 
 ;;;###autoload


### PR DESCRIPTION
this fixes following bug:
When `(point)` is at the end of a line in an wdired buffer, calling `hungry-delete-backward` results in `(point)` going to the beginning of the next line (first editable char).

But this action actually should delete a character. This commit tries to fix that.