### PR TITLE
detect rectangular selection using rectangle-mark-mode var

### DIFF
--- a/hungry-delete.el
+++ b/hungry-delete.el
@@ -109,7 +109,7 @@ KILLFLAG is set if N was explicitly specified."
   (interactive "p\nP")
   (unless (integerp n)
     (signal 'wrong-type-argument (list 'integerp n)))
-  (if cua--rectangle (delete-forward-char n killflag)
+  (if rectangle-mark-mode (delete-forward-char n killflag)
   (cond ((and
           (use-region-p)
 	      delete-active-region
@@ -147,7 +147,7 @@ arg, and KILLFLAG is set if N is explicitly specified."
   (interactive "p\nP")
   (unless (integerp n)
     (signal 'wrong-type-argument (list 'integerp n)))
-  (if cua--rectangle (delete-backward-char n killflag)
+  (if rectangle-mark-mode (delete-backward-char n killflag)
     (cond ((and
             (use-region-p)
             delete-active-region


### PR DESCRIPTION
Detect rectangular selection using `rectangle-mark-mode` variable. Currently used `cua--rectangle` variable only works when `cua-mode` was loaded.