### PR TITLE
Add reluctant joining

### DIFF
--- a/hungry-delete.el
+++ b/hungry-delete.el
@@ -45,9 +45,10 @@
 (defvar hungry-delete-mode-map (make-keymap)
   "Keymap for hungry-delete-minor-mode.")
 
-(defvar hungry-delete-join-reluctantly nil
+(defcustom hungry-delete-join-reluctantly nil
   "If truthy, deletion will insert a space between two words when they would have been joined
-and are seperated by more than just one space")
+and are seperated by more than just one space"
+  :type :boolean)
 
 (if (fboundp 'delete-forward-char)
     (define-key hungry-delete-mode-map [remap delete-forward-char] 'hungry-delete-forward))


### PR DESCRIPTION
Hi, I was a little annoyed by how hungry delete would often join words when I really just wanted to delete some extra whitespace between them.

``` common-lisp
;; State A
(defun foo ()    (bar))
                 ^
;; Press backspace
;; State B
(defun foo ()(bar))
             ^
```

I feel that better behavior for hungry deletion in state A would be to transition to the following state

``` common-lisp
;; State C
(defun foo () (bar))
              ^
```

From where the user could press backspace again to get to state C

This change adds a switch, `hungry-delete-join-reluctantly`, to enable the above behavior. The switch is off by default of course, so the default behavior should be unchanged

From my rudimentary testing, it seems to work as I expect it to. Let me know if the code looks good and if you'd consider merging the PR. If so, I'll amend the readme to add some documentation as well